### PR TITLE
Fix for case-sensitive FS. bootX64.efi used to be refered as bootx64.efi

### DIFF
--- a/Mac-Linux-USB-Loader/SBDocument.m
+++ b/Mac-Linux-USB-Loader/SBDocument.m
@@ -188,7 +188,7 @@
 	//NSString *enterpriseInstallFileName = [installDirectory stringByAppendingString:@"bootX64.efi"];
 
 	// Set the size of the file to be the max value of the progress bar.
-	NSString *enterprisePath = [sourceLocation.path stringByAppendingPathComponent:@"bootx64.efi"];
+	NSString *enterprisePath = [sourceLocation.path stringByAppendingPathComponent:@"bootX64.efi"];
 	NSString *grubPath = [sourceLocation.path stringByAppendingPathComponent:@"boot.efi"];
 	if (![manager fileExistsAtPath:enterprisePath isDirectory:NULL] || ![manager fileExistsAtPath:grubPath isDirectory:NULL]) {
 		NSAlert *alert = [[NSAlert alloc] init];

--- a/Mac-Linux-USB-Loader/SBEnterprisePreferencesViewController.m
+++ b/Mac-Linux-USB-Loader/SBEnterprisePreferencesViewController.m
@@ -255,7 +255,7 @@
 
 - (BOOL)verifyEnterpriseInstallationDirectory:(NSString *)path {
 	NSFileManager *manager = [NSFileManager defaultManager];
-	BOOL isValid = [manager fileExistsAtPath:[path stringByAppendingPathComponent:@"boot.efi"]] && [manager fileExistsAtPath:[path stringByAppendingPathComponent:@"bootx64.efi"]];
+	BOOL isValid = [manager fileExistsAtPath:[path stringByAppendingPathComponent:@"boot.efi"]] && [manager fileExistsAtPath:[path stringByAppendingPathComponent:@"bootX64.efi"]];
 	return isValid;
 }
 

--- a/Mac-Linux-USB-Loader/SBUSBDevice.m
+++ b/Mac-Linux-USB-Loader/SBUSBDevice.m
@@ -131,7 +131,7 @@ typedef enum {
 	// Create an operation for the operation queue to copy over the necessary files.
 	attachedDocument = document;
 	USBIsInUse = YES;
-	NSString *finalEnterpriseCopyPath = [NSString stringWithFormat:@"/Volumes/%@/efi/boot/bootx64.efi",
+	NSString *finalEnterpriseCopyPath = [NSString stringWithFormat:@"/Volumes/%@/efi/boot/bootX64.efi",
 	                              self.name];
 	NSString *finalGRUBCopyPath = [NSString stringWithFormat:@"/Volumes/%@/efi/boot/boot.efi",
 										 self.name];
@@ -144,7 +144,7 @@ typedef enum {
 	copyfile_state_t s;
 	s = copyfile_state_alloc();
 
-	const char *fromPath = [[source.path stringByAppendingPathComponent:@"bootx64.efi"] UTF8String];
+	const char *fromPath = [[source.path stringByAppendingPathComponent:@"bootX64.efi"] UTF8String];
 	const char *toPath = [finalEnterpriseCopyPath UTF8String];
 
 	NSLog(@"from: %s to: %s", fromPath, toPath);


### PR DESCRIPTION
If one has app on case-sensitive FS, it fails to find Enterprise binary
because it is referenced with small "x" in code, but is included in app
package with big "X".

Really fixes issue #62 for me.