### PR TITLE
Add support for flash drives reporting themselves as hard drives.

### DIFF
--- a/Mac-Linux-USB-Loader/Base.lproj/SBGeneralPreferencesViewController.xib
+++ b/Mac-Linux-USB-Loader/Base.lproj/SBGeneralPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
         <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <objects>
@@ -20,14 +20,12 @@
             <subviews>
                 <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Mqp-7t-iHQ">
                     <rect key="frame" x="12" y="115" width="561" height="5"/>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <font key="titleFont" metaFont="system"/>
                 </box>
                 <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZY5-Xk-lAz">
                     <rect key="frame" x="474" y="122" width="105" height="32"/>
-                    <animations/>
                     <buttonCell key="cell" type="push" title="Clear Now" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="j9p-k1-kBV">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -49,7 +47,6 @@
                         <subviews>
                             <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rlJ-OH-hmA">
                                 <rect key="frame" x="16" y="58" width="401" height="18"/>
-                                <animations/>
                                 <buttonCell key="cell" type="check" title="Accept HFS+ Formatted Drives" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9HT-f6-zfH">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -60,7 +57,6 @@
                             </button>
                             <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1GF-fo-Apu">
                                 <rect key="frame" x="16" y="35" width="401" height="18"/>
-                                <animations/>
                                 <buttonCell key="cell" type="check" title="Hide Enterprise Configuration File" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="CG7-vV-ura">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -69,8 +65,22 @@
                                     <binding destination="aRH-Yv-lWu" name="value" keyPath="values.HideConfigurationFile" id="1mV-BO-uzH"/>
                                 </connections>
                             </button>
+                            <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="S2N-71-0Ys">
+                                <rect key="frame" x="16" y="12" width="401" height="18"/>
+                                <buttonCell key="cell" type="check" title="Accept Hard Drives" bezelStyle="regularSquare" imagePosition="left" inset="2" id="auA-Ob-KZq">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <binding destination="aRH-Yv-lWu" name="value" keyPath="values.AcceptHardDrives" id="baT-ZV-zRq"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <animations/>
+                        <constraints>
+                            <constraint firstItem="S2N-71-0Ys" firstAttribute="trailing" secondItem="rlJ-OH-hmA" secondAttribute="trailing" id="5Rd-df-JsX"/>
+                            <constraint firstItem="S2N-71-0Ys" firstAttribute="leading" secondItem="rlJ-OH-hmA" secondAttribute="leading" id="KL3-cS-RcJ"/>
+                            <constraint firstItem="S2N-71-0Ys" firstAttribute="top" secondItem="1GF-fo-Apu" secondAttribute="bottom" constant="9" id="XKm-9S-IN6"/>
+                        </constraints>
                     </view>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="1GF-fo-Apu" secondAttribute="bottom" constant="34" id="04b-v3-bCh"/>
@@ -81,7 +91,6 @@
                         <constraint firstItem="1GF-fo-Apu" firstAttribute="top" secondItem="rlJ-OH-hmA" secondAttribute="bottom" constant="9" id="pUq-bA-H8q"/>
                         <constraint firstItem="rlJ-OH-hmA" firstAttribute="top" secondItem="nPg-bg-bVL" secondAttribute="top" constant="25" id="pid-fI-uST"/>
                     </constraints>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </box>
@@ -90,7 +99,6 @@
                     <constraints>
                         <constraint firstAttribute="width" priority="250" constant="328" id="bfU-Ms-9t1"/>
                     </constraints>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Periodically Clear Caches and Old ISO Downloads" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XrG-IX-Jnc">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -116,7 +124,6 @@
                 <constraint firstAttribute="centerX" secondItem="s4C-gM-3i6" secondAttribute="centerX" constant="4.5" id="wgb-gI-xlc"/>
                 <constraint firstItem="Mqp-7t-iHQ" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="12" id="wjh-nJ-YV7"/>
             </constraints>
-            <animations/>
             <point key="canvasLocation" x="466.5" y="256"/>
         </customView>
         <userDefaultsController id="xGH-KJ-pxb"/>

--- a/Mac-Linux-USB-Loader/SBAppDelegate.m
+++ b/Mac-Linux-USB-Loader/SBAppDelegate.m
@@ -279,11 +279,12 @@ const NSString *SBBundledEnterpriseVersionNumber = @"0.3.2";
 	NSString *description, *volumeType;
 
 	BOOL acceptHFSDrives = [[NSUserDefaults standardUserDefaults] boolForKey:@"AcceptHFSDrives"];
+    BOOL acceptHardDrives = [[NSUserDefaults standardUserDefaults] boolForKey:@"AcceptHardDrives"];
 
 	for (NSURL *mountURL in volumes) {
 		NSString *usbDeviceMountPoint = [mountURL path];
 		if ([[NSWorkspace sharedWorkspace] getFileSystemInfoForPath:usbDeviceMountPoint isRemovable:&isRemovable isWritable:&isWritable isUnmountable:&isUnmountable description:&description type:&volumeType]) {
-			if (isRemovable && isWritable && isUnmountable) {
+			if (isWritable && (acceptHardDrives || (isRemovable && isUnmountable))) {
 				NSLog(@"Detected eligible volume at %@. Type: %@", usbDeviceMountPoint, volumeType);
 
 				if ([usbDeviceMountPoint isEqualToString:@"/"]) {

--- a/Mac-Linux-USB-Loader/defaults.plist
+++ b/Mac-Linux-USB-Loader/defaults.plist
@@ -12,6 +12,8 @@
 	<integer>0</integer>
 	<key>AcceptHFSDrives</key>
 	<false/>
+	<key>AcceptHardDrives</key>
+	<false/>
 	<key>HideConfigurationFile</key>
 	<true/>
 	<key>SimultaneousDownloadOperationsNumber</key>


### PR DESCRIPTION
I picked a USB drive at random to make a bootable flash drive and came across the "doesn't detect my USB flash drive" issue. It looks like it's probably related to #29 - after comparing a few flash drives, the problem one was reporting itself as a hard drive rather than a removable drive.

It sounds like that change is a requirement for getting Windows 8 certification or something like that. Anyway, the Mac doesn't care and will boot from them so I've added a new configuration option in the experimental preferences section.

"Accept hard drives" will include these USB flash drives (and external hard drives and such too, although I haven't tested with one) and allow them to be selected. I've tested this and have successfully booted Linux with the previously unrecognised flash drive.

I haven't added translations for the new option - I'm not sure I trust Google Translate for that! ;)